### PR TITLE
fix: 子カテゴリのリダイレクト先を親込みパスに修正

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -7,7 +7,7 @@
 /*/feed/           /rss.xml   301
 
 # Category（日本語slug → enSlug）
-/category/%E7%AF%80%E7%B4%84/ /category/savings/ 301
+/category/%E7%AF%80%E7%B4%84/ /category/fire/savings/ 301
 
 # Tag（日本語slug → enSlug）
 /tag/%E3%83%A1%E3%83%BC%E3%83%AB/ /tag/mail/ 301

--- a/scripts/build-redirects.ts
+++ b/scripts/build-redirects.ts
@@ -2,6 +2,7 @@ import { readFile, writeFile } from 'node:fs/promises'
 import { glob } from 'node:fs/promises'
 import matter from 'gray-matter'
 import type { TermDict } from './lib/taxonomy'
+import { categoryUrlPath } from '../src/lib/taxonomy'
 import { selectRedirectTerms, buildRedirects } from './lib/redirects'
 
 const CATEGORIES_JSON = 'data/categories.json'
@@ -34,7 +35,10 @@ async function main() {
 
   const { cats, tags } = await collectUsedSlugs()
 
-  const categories = selectRedirectTerms(catDict, cats)
+  const categories = selectRedirectTerms(catDict, cats).map(({ slug, enSlug }) => ({
+    slug,
+    enSlug: categoryUrlPath(enSlug),
+  }))
   const tagTerms = selectRedirectTerms(tagDict, tags)
 
   const text = buildRedirects({ categories, tags: tagTerms })


### PR DESCRIPTION
## 原因

`savings` カテゴリは `fire` の子カテゴリのため、実際の URL は `/category/fire/savings/`。
`build-redirects.ts` が `enSlug`（`savings`）をそのまま使っていたため、転送先が `/category/savings/`（404）になっていた。

## 修正

`build-redirects.ts` で `categoryUrlPath(enSlug)` を使い、親込みパス（`fire/savings`）を転送先に設定するよう変更。

## 確認

- [ ] `https://shiimanblog.com/category/%E7%AF%80%E7%B4%84/` → `/category/fire/savings/` に301リダイレクトされること