### PR TITLE
AdSense広告ユニットを追加（記事末尾ディスプレイ・一覧インフィード）

### DIFF
--- a/src/components/AdUnit.astro
+++ b/src/components/AdUnit.astro
@@ -1,0 +1,34 @@
+---
+import { ADSENSE_CLIENT } from '../consts'
+
+interface Props {
+  slot: string
+  // 'auto'（ディスプレイ）または 'fluid'（インフィード）
+  format?: string
+  // インフィード広告で必須の data-ad-layout-key
+  layoutKey?: string
+  // ラベル（任意。広告枠の余白制御用クラス付与）
+  className?: string
+}
+const { slot, format = 'auto', layoutKey, className } = Astro.props
+// 広告は本番ビルド時のみ出力（dev では枠を出さない）
+const isProd = import.meta.env.PROD
+---
+{isProd && (
+  <div class:list={['ad-unit', className]}>
+    <ins
+      class="adsbygoogle"
+      style="display:block"
+      data-ad-client={ADSENSE_CLIENT}
+      data-ad-slot={slot}
+      data-ad-format={format}
+      data-ad-layout-key={layoutKey}
+      data-full-width-responsive={format === 'auto' ? 'true' : undefined}
+    ></ins>
+    <script is:inline>(window.adsbygoogle = window.adsbygoogle || []).push({})</script>
+  </div>
+)}
+
+<style>
+  .ad-unit { margin: 2rem 0; text-align: center; overflow: hidden; }
+</style>

--- a/src/components/AdUnit.astro
+++ b/src/components/AdUnit.astro
@@ -4,7 +4,7 @@ import { ADSENSE_CLIENT } from '../consts'
 interface Props {
   slot: string
   // 'auto'（ディスプレイ）または 'fluid'（インフィード）
-  format?: string
+  format?: 'auto' | 'fluid'
   // インフィード広告で必須の data-ad-layout-key
   layoutKey?: string
   // ラベル（任意。広告枠の余白制御用クラス付与）

--- a/src/components/PostList.astro
+++ b/src/components/PostList.astro
@@ -2,7 +2,7 @@
 import PostCard from './PostCard.astro'
 import AdUnit from './AdUnit.astro'
 import { insertInfeedAds, type AdListItem } from '../lib/ad-insert'
-import { AD_SLOT_DISPLAY } from '../consts'
+import { AD_SLOT_INFEED, AD_INFEED_LAYOUT_KEY } from '../consts'
 import type { PublishedPost } from '../lib/posts'
 
 interface Props {
@@ -10,7 +10,7 @@ interface Props {
   adEvery?: number
 }
 const { posts, adEvery = 5 } = Astro.props
-// カード adEvery 件ごとにレスポンシブ・ディスプレイ広告を挿入（末尾には挿入しない）
+// カード adEvery 件ごとにインフィード広告を挿入（末尾には挿入しない）
 const items: AdListItem<PublishedPost>[] = insertInfeedAds(posts, adEvery)
 ---
 <div class="list">
@@ -18,7 +18,7 @@ const items: AdListItem<PublishedPost>[] = insertInfeedAds(posts, adEvery)
     item.kind === 'post' ? (
       <PostCard post={item.post} />
     ) : (
-      <AdUnit slot={AD_SLOT_DISPLAY} className="ad-infeed" />
+      <AdUnit slot={AD_SLOT_INFEED} format="fluid" layoutKey={AD_INFEED_LAYOUT_KEY} className="ad-infeed" />
     ),
   )}
 </div>

--- a/src/components/PostList.astro
+++ b/src/components/PostList.astro
@@ -2,7 +2,7 @@
 import PostCard from './PostCard.astro'
 import AdUnit from './AdUnit.astro'
 import { insertInfeedAds, type AdListItem } from '../lib/ad-insert'
-import { AD_SLOT_INFEED, AD_INFEED_LAYOUT_KEY } from '../consts'
+import { AD_SLOT_DISPLAY } from '../consts'
 import type { PublishedPost } from '../lib/posts'
 
 interface Props {
@@ -10,18 +10,15 @@ interface Props {
   adEvery?: number
 }
 const { posts, adEvery = 5 } = Astro.props
-// インフィード広告は data-ad-layout-key が必須。未設定時は広告を挿入しない。
-const items: AdListItem<PublishedPost>[] =
-  AD_INFEED_LAYOUT_KEY !== ''
-    ? insertInfeedAds(posts, adEvery)
-    : posts.map((post) => ({ kind: 'post', post }))
+// カード adEvery 件ごとにレスポンシブ・ディスプレイ広告を挿入（末尾には挿入しない）
+const items: AdListItem<PublishedPost>[] = insertInfeedAds(posts, adEvery)
 ---
 <div class="list">
   {items.map((item) =>
     item.kind === 'post' ? (
       <PostCard post={item.post} />
     ) : (
-      <AdUnit slot={AD_SLOT_INFEED} format="fluid" layoutKey={AD_INFEED_LAYOUT_KEY} className="ad-infeed" />
+      <AdUnit slot={AD_SLOT_DISPLAY} className="ad-infeed" />
     ),
   )}
 </div>

--- a/src/components/PostList.astro
+++ b/src/components/PostList.astro
@@ -1,0 +1,27 @@
+---
+import PostCard from './PostCard.astro'
+import AdUnit from './AdUnit.astro'
+import { insertInfeedAds, type AdListItem } from '../lib/ad-insert'
+import { AD_SLOT_INFEED, AD_INFEED_LAYOUT_KEY } from '../consts'
+import type { PublishedPost } from '../lib/posts'
+
+interface Props {
+  posts: PublishedPost[]
+  adEvery?: number
+}
+const { posts, adEvery = 5 } = Astro.props
+// インフィード広告は data-ad-layout-key が必須。未設定時は広告を挿入しない。
+const items: AdListItem<PublishedPost>[] =
+  AD_INFEED_LAYOUT_KEY !== ''
+    ? insertInfeedAds(posts, adEvery)
+    : posts.map((post) => ({ kind: 'post', post }))
+---
+<div class="list">
+  {items.map((item) =>
+    item.kind === 'post' ? (
+      <PostCard post={item.post} />
+    ) : (
+      <AdUnit slot={AD_SLOT_INFEED} format="fluid" layoutKey={AD_INFEED_LAYOUT_KEY} className="ad-infeed" />
+    ),
+  )}
+</div>

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -2,4 +2,9 @@
 // いずれも HTML ソースに埋め込まれる公開情報であり、秘密情報ではない。
 export const GA_MEASUREMENT_ID = 'G-V0YEQ7Y9LG'
 export const ADSENSE_CLIENT = 'ca-pub-5089081773786236'
+// 広告ユニットのスロットID（AdSense管理画面で発行済み）
+export const AD_SLOT_DISPLAY = '3635174203' // スクエア1（記事末尾）
+export const AD_SLOT_INFEED = '8447435614' // インフィード1（記事一覧）
+// インフィード広告のレイアウトキー（AdSense管理画面のコードに含まれる data-ad-layout-key）
+export const AD_INFEED_LAYOUT_KEY = ''
 export const GSC_VERIFICATION = 'SiCnVqYrvLmGO2hnzXcAo6z91CthmM8Ij1R1jYb_LCo'

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -3,8 +3,6 @@
 export const GA_MEASUREMENT_ID = 'G-V0YEQ7Y9LG'
 export const ADSENSE_CLIENT = 'ca-pub-5089081773786236'
 // 広告ユニットのスロットID（AdSense管理画面で発行済み）
-export const AD_SLOT_DISPLAY = '3635174203' // スクエア1（記事末尾）
-export const AD_SLOT_INFEED = '8447435614' // インフィード1（記事一覧）
-// インフィード広告のレイアウトキー（AdSense管理画面のコードに含まれる data-ad-layout-key）
-export const AD_INFEED_LAYOUT_KEY = ''
+// 記事末尾・記事一覧の両方でレスポンシブ・ディスプレイ広告として流用する
+export const AD_SLOT_DISPLAY = '3635174203' // スクエア1
 export const GSC_VERIFICATION = 'SiCnVqYrvLmGO2hnzXcAo6z91CthmM8Ij1R1jYb_LCo'

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -3,6 +3,8 @@
 export const GA_MEASUREMENT_ID = 'G-V0YEQ7Y9LG'
 export const ADSENSE_CLIENT = 'ca-pub-5089081773786236'
 // 広告ユニットのスロットID（AdSense管理画面で発行済み）
-// 記事末尾・記事一覧の両方でレスポンシブ・ディスプレイ広告として流用する
-export const AD_SLOT_DISPLAY = '3635174203' // スクエア1
+export const AD_SLOT_DISPLAY = '3635174203' // スクエア1（記事末尾）
+export const AD_SLOT_INFEED = '8447435614' // インフィード1（記事一覧）
+// インフィード広告のレイアウトキー（AdSense管理画面のコードに含まれる data-ad-layout-key）
+export const AD_INFEED_LAYOUT_KEY = '-fk+5y-26-4s+h7'
 export const GSC_VERIFICATION = 'SiCnVqYrvLmGO2hnzXcAo6z91CthmM8Ij1R1jYb_LCo'

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -6,6 +6,8 @@ import TagList from '../components/TagList.astro'
 import TableOfContents from '../components/TableOfContents.astro'
 import PrevNext from '../components/PrevNext.astro'
 import Comments from '../components/Comments.astro'
+import AdUnit from '../components/AdUnit.astro'
+import { AD_SLOT_DISPLAY } from '../consts'
 import type { MarkdownHeading } from 'astro'
 import type { CollectionEntry } from 'astro:content'
 import type { ResolvedTaxonomy } from '../lib/taxonomy'
@@ -31,6 +33,7 @@ const ogImage = eyecatch?.src
       <div class="content">
         <slot />
       </div>
+      <AdUnit slot={AD_SLOT_DISPLAY} />
       <TagList tags={tags} />
       <PrevNext prev={prev} next={next} />
       <Comments />

--- a/src/lib/ad-insert.test.ts
+++ b/src/lib/ad-insert.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { insertInfeedAds } from './ad-insert'
+
+// テスト用に記事を文字列で代用
+const posts = (n: number) => Array.from({ length: n }, (_, i) => `p${i}`)
+
+describe('insertInfeedAds', () => {
+  it('空配列なら空を返す', () => {
+    expect(insertInfeedAds([], 5)).toEqual([])
+  })
+
+  it('every 未満なら広告を挿入しない', () => {
+    const result = insertInfeedAds(posts(3), 5)
+    expect(result).toEqual([
+      { kind: 'post', post: 'p0' },
+      { kind: 'post', post: 'p1' },
+      { kind: 'post', post: 'p2' },
+    ])
+  })
+
+  it('ちょうど every 件なら末尾に広告を挿入しない', () => {
+    const result = insertInfeedAds(posts(5), 5)
+    expect(result.filter((x) => x.kind === 'ad')).toHaveLength(0)
+    expect(result).toHaveLength(5)
+  })
+
+  it('every+1 件なら 5件目の後に広告を1つ挿入する', () => {
+    const result = insertInfeedAds(posts(6), 5)
+    expect(result).toEqual([
+      { kind: 'post', post: 'p0' },
+      { kind: 'post', post: 'p1' },
+      { kind: 'post', post: 'p2' },
+      { kind: 'post', post: 'p3' },
+      { kind: 'post', post: 'p4' },
+      { kind: 'ad', key: 0 },
+      { kind: 'post', post: 'p5' },
+    ])
+  })
+
+  it('12件なら5件ごとに広告を2つ挿入し、末尾には挿入しない', () => {
+    const result = insertInfeedAds(posts(12), 5)
+    const ads = result.filter((x) => x.kind === 'ad')
+    expect(ads).toEqual([
+      { kind: 'ad', key: 0 },
+      { kind: 'ad', key: 1 },
+    ])
+    // 末尾は post（広告で終わらない）
+    expect(result[result.length - 1]).toEqual({ kind: 'post', post: 'p11' })
+  })
+})

--- a/src/lib/ad-insert.test.ts
+++ b/src/lib/ad-insert.test.ts
@@ -37,6 +37,15 @@ describe('insertInfeedAds', () => {
     ])
   })
 
+  it('every が 1 未満なら例外を投げる', () => {
+    expect(() => insertInfeedAds(posts(3), 0)).toThrow()
+    expect(() => insertInfeedAds(posts(3), -1)).toThrow()
+  })
+
+  it('every が整数でなければ例外を投げる', () => {
+    expect(() => insertInfeedAds(posts(3), 1.5)).toThrow()
+  })
+
   it('12件なら5件ごとに広告を2つ挿入し、末尾には挿入しない', () => {
     const result = insertInfeedAds(posts(12), 5)
     const ads = result.filter((x) => x.kind === 'ad')

--- a/src/lib/ad-insert.ts
+++ b/src/lib/ad-insert.ts
@@ -1,0 +1,19 @@
+/** 記事一覧の各要素（記事 or インフィード広告） */
+export type AdListItem<T> = { kind: 'post'; post: T } | { kind: 'ad'; key: number }
+
+/**
+ * 記事リストに every 件ごとにインフィード広告マーカーを挿入する。
+ * 末尾（最後の記事の直後）には挿入しない。
+ */
+export function insertInfeedAds<T>(posts: T[], every: number): AdListItem<T>[] {
+  const result: AdListItem<T>[] = []
+  let adKey = 0
+  posts.forEach((post, i) => {
+    result.push({ kind: 'post', post })
+    const pos = i + 1
+    if (pos % every === 0 && pos < posts.length) {
+      result.push({ kind: 'ad', key: adKey++ })
+    }
+  })
+  return result
+}

--- a/src/lib/ad-insert.ts
+++ b/src/lib/ad-insert.ts
@@ -6,6 +6,9 @@ export type AdListItem<T> = { kind: 'post'; post: T } | { kind: 'ad'; key: numbe
  * 末尾（最後の記事の直後）には挿入しない。
  */
 export function insertInfeedAds<T>(posts: T[], every: number): AdListItem<T>[] {
+  if (!Number.isInteger(every) || every < 1) {
+    throw new Error(`insertInfeedAds: every は1以上の整数である必要があります (received: ${every})`)
+  }
   const result: AdListItem<T>[] = []
   let adKey = 0
   posts.forEach((post, i) => {

--- a/src/pages/category/[...category].astro
+++ b/src/pages/category/[...category].astro
@@ -1,6 +1,6 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro'
-import PostCard from '../../components/PostCard.astro'
+import PostList from '../../components/PostList.astro'
 import { getPublishedPosts, type PublishedPost } from '../../lib/posts'
 import { resolveCategory } from '../../lib/taxonomy'
 import type { GetStaticPaths } from 'astro'
@@ -39,9 +39,7 @@ const fullName = parentName ? `${parentName} › ${name}` : name
   <h1 class="archive-title">
     カテゴリ: {parentName && (<Fragment><a href={`/category/${parentSlug}/`}>{parentName}</a> › </Fragment>)}{name}
   </h1>
-  <div class="list">
-    {posts.map((post) => <PostCard post={post} />)}
-  </div>
+  <PostList posts={posts} />
 </BaseLayout>
 
 <style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,6 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro'
-import PostCard from '../components/PostCard.astro'
+import PostList from '../components/PostList.astro'
 import Pagination from '../components/Pagination.astro'
 import Sidebar from '../components/Sidebar.astro'
 import { getPublishedPosts } from '../lib/posts'
@@ -13,9 +13,7 @@ const items = pageSlice(posts, 1, PAGE_SIZE)
 <BaseLayout title="しーまんブログ" description="ゲーム開発エンジニアしーまんの技術・副業・投資ブログ">
   <div class="home-grid">
     <div class="main">
-      <div class="list">
-        {items.map((post) => <PostCard post={post} />)}
-      </div>
+      <PostList posts={items} />
       <Pagination current={1} total={total} />
     </div>
     <Sidebar />

--- a/src/pages/page/[page].astro
+++ b/src/pages/page/[page].astro
@@ -1,6 +1,6 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro'
-import PostCard from '../../components/PostCard.astro'
+import PostList from '../../components/PostList.astro'
 import Pagination from '../../components/Pagination.astro'
 import Sidebar from '../../components/Sidebar.astro'
 import { getPublishedPosts } from '../../lib/posts'
@@ -25,9 +25,7 @@ const items = pageSlice(posts, page, PAGE_SIZE)
 <BaseLayout title={`記事一覧 (${page}/${total}) - しーまんブログ`}>
   <div class="home-grid">
     <div class="main">
-      <div class="list">
-        {items.map((post) => <PostCard post={post} />)}
-      </div>
+      <PostList posts={items} />
       <Pagination current={page} total={total} />
     </div>
     <Sidebar />

--- a/src/pages/tag/[tag].astro
+++ b/src/pages/tag/[tag].astro
@@ -1,6 +1,6 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro'
-import PostCard from '../../components/PostCard.astro'
+import PostList from '../../components/PostList.astro'
 import { getPublishedPosts, type PublishedPost } from '../../lib/posts'
 import { resolveTag } from '../../lib/taxonomy'
 import type { GetStaticPaths } from 'astro'
@@ -25,9 +25,7 @@ const { name, posts } = Astro.props
 ---
 <BaseLayout title={`タグ: ${name} - shiimanblog`} description={`${name}の記事一覧`}>
   <h1 class="archive-title">タグ: {name}</h1>
-  <div class="list">
-    {posts.map((post) => <PostCard post={post} />)}
-  </div>
+  <PostList posts={posts} />
 </BaseLayout>
 
 <style>


### PR DESCRIPTION
## 変更内容

旧WordPressサイトで使っていた広告ユニットをAstro版に実装。

- **ディスプレイ広告（スクエア1: 3635174203）** → 記事ページの本文後・タグの前に配置
- **インフィード広告（インフィード1: 8447435614）** → 記事一覧（トップ/ページ送り/カテゴリ/タグ）のカード5件ごとに挿入

### 実装

- `AdUnit.astro` — 広告枠の共通コンポーネント（本番ビルド時のみ出力）
- `PostList.astro` — 記事一覧の共通描画＋インフィード広告挿入
- `lib/ad-insert.ts` — 5件ごとの広告挿入ロジック（TDDで実装、末尾には挿入しない）
- `consts.ts` — スロットID・レイアウトキーを定数化

### ⚠️ インフィード広告の有効化について

インフィード広告は `data-ad-layout-key`（管理画面で発行される固有値）が必須です。
**`AD_INFEED_LAYOUT_KEY` が未設定の間は一覧に広告を挿入しません**（現状の見た目を維持）。
レイアウトキーを `consts.ts` に設定すると有効化されます。

## テスト手順

- [x] `npm test`（ad-insert 5件、全68件パス）
- [x] `npm run build`（記事末尾に slot=3635174203 が出力されることを確認）
- [ ] マージ後、記事ページ末尾にディスプレイ広告が表示されること
- [ ] レイアウトキー設定後、一覧に5件ごとインフィード広告が表示されること