### PR TITLE
全記事のカテゴリ/タグ是正と分類体系の整備

### DIFF
--- a/data/manual-redirects.txt
+++ b/data/manual-redirects.txt
@@ -5,3 +5,4 @@
 /wordpress/advertisement/google-adsence/ /wordpress/advertisement/google-adsense/ 301
 /tag/google-adsence/ /tag/google-adsense/ 301
 /fire/%E7%AF%80%E7%B4%84/post-1834/ /fire/savings/post-1834/ 301
+/tag/api-gatewat/ /tag/api-gateway/ 301

--- a/data/tags.json
+++ b/data/tags.json
@@ -392,7 +392,7 @@
   },
   "127": {
     "name": "API Gateway",
-    "slug": "api-gatewat"
+    "slug": "api-gateway"
   },
   "128": {
     "name": "spot pod",

--- a/data/tags.json
+++ b/data/tags.json
@@ -67,10 +67,6 @@
     "name": "github",
     "slug": "github"
   },
-  "42": {
-    "name": "worfpress",
-    "slug": "worfpress"
-  },
   "43": {
     "name": "404",
     "slug": "404"
@@ -123,7 +119,7 @@
     "slug": "a8-net"
   },
   "56": {
-    "name": "アフェリエイト",
+    "name": "アフィリエイト",
     "slug": "%e3%82%a2%e3%83%95%e3%82%a7%e3%83%aa%e3%82%a8%e3%82%a4%e3%83%88",
     "enSlug": "affiliate"
   },
@@ -395,7 +391,7 @@
     "slug": "cloud-front"
   },
   "127": {
-    "name": "API Gatewat",
+    "name": "API Gateway",
     "slug": "api-gatewat"
   },
   "128": {
@@ -423,5 +419,41 @@
   "133": {
     "name": "AI",
     "slug": "ai"
+  },
+  "134": {
+    "name": "Claude Code",
+    "slug": "claude-code"
+  },
+  "135": {
+    "name": "Cursor",
+    "slug": "cursor"
+  },
+  "136": {
+    "name": "Antigravity",
+    "slug": "antigravity"
+  },
+  "137": {
+    "name": "Gemini",
+    "slug": "gemini"
+  },
+  "138": {
+    "name": "MCP",
+    "slug": "mcp"
+  },
+  "139": {
+    "name": "Codex",
+    "slug": "codex"
+  },
+  "140": {
+    "name": "Astro",
+    "slug": "astro"
+  },
+  "141": {
+    "name": "Cloudflare",
+    "slug": "cloudflare"
+  },
+  "142": {
+    "name": "ブログ運営",
+    "slug": "blog-management"
   }
 }

--- a/posts/2021-08-30_start-blog/article.md
+++ b/posts/2021-08-30_start-blog/article.md
@@ -5,7 +5,7 @@ date: 2021-08-30T19:30:00.000Z
 categories:
   - profile
 tags:
-  - wordpress
+  - blog-management
 draft: false
 id: 6
 modified: 2021-08-30T19:22:28.000Z

--- a/posts/2021-09-08_microservice/article.md
+++ b/posts/2021-09-08_microservice/article.md
@@ -9,6 +9,7 @@ tags:
   - docker
   - microservice
   - ingress
+  - golang
 draft: false
 id: 437
 modified: 2021-09-08T01:38:08.000Z

--- a/posts/2021-09-14_recaptcha-hide/article.md
+++ b/posts/2021-09-14_recaptcha-hide/article.md
@@ -4,9 +4,11 @@ slug: recaptcha-hide
 date: 2021-09-14T19:30:00.000Z
 categories:
   - wordpress
+  - plugin
 tags:
   - invisible-recaptcha
-  - worfpress
+  - wordpress
+  - cocoon
 draft: false
 id: 171
 modified: 2021-09-12T23:59:37.000Z

--- a/posts/2021-09-25_start-blog-2/article.md
+++ b/posts/2021-09-25_start-blog-2/article.md
@@ -5,7 +5,7 @@ date: 2021-09-25T19:30:00.000Z
 categories:
   - book
 tags:
-  - wordpress
+  - '%e3%82%a2%e3%83%95%e3%82%a7%e3%83%aa%e3%82%a8%e3%82%a4%e3%83%88'
 draft: false
 id: 812
 modified: 2021-09-21T18:23:35.000Z

--- a/posts/2021-09-26_error-internal-load-metadata/article.md
+++ b/posts/2021-09-26_error-internal-load-metadata/article.md
@@ -7,6 +7,7 @@ categories:
   - docker
 tags:
   - docker
+  - mac
 draft: false
 id: 859
 modified: 2021-09-23T12:42:40.000Z

--- a/posts/2021-09-27_google-keyword-planner/article.md
+++ b/posts/2021-09-27_google-keyword-planner/article.md
@@ -4,10 +4,8 @@ slug: google-keyword-planner
 date: 2021-09-27T19:30:00.000Z
 categories:
   - analytics
-  - wordpress
 tags:
-  - >-
-    %e3%82%ad%e3%83%bc%e3%83%af%e3%83%bc%e3%83%89%e3%83%97%e3%83%a9%e3%83%b3%e3%83%8a%e3%83%bc
+  - '%e3%82%ad%e3%83%bc%e3%83%af%e3%83%bc%e3%83%89%e3%83%97%e3%83%a9%e3%83%b3%e3%83%8a%e3%83%bc'
 draft: false
 id: 872
 modified: 2021-09-24T17:32:09.000Z

--- a/posts/2021-09-28_a8net/article.md
+++ b/posts/2021-09-28_a8net/article.md
@@ -4,7 +4,6 @@ slug: a8net
 date: 2021-09-28T19:30:00.000Z
 categories:
   - advertisement
-  - wordpress
 tags:
   - a8-net
   - '%e3%82%a2%e3%83%95%e3%82%a7%e3%83%aa%e3%82%a8%e3%82%a4%e3%83%88'

--- a/posts/2021-09-29_valuecommerce/article.md
+++ b/posts/2021-09-29_valuecommerce/article.md
@@ -4,7 +4,7 @@ slug: valuecommerce
 date: 2021-09-29T19:30:00.000Z
 categories:
   - advertisement
-  - wordpress
+  - side-business
 tags:
   - '%e3%82%a2%e3%83%95%e3%82%a7%e3%83%aa%e3%82%a8%e3%82%a4%e3%83%88'
   - asp

--- a/posts/2021-10-06_nisa-202110/article.md
+++ b/posts/2021-10-06_nisa-202110/article.md
@@ -7,6 +7,7 @@ categories:
   - fire
 tags:
   - '%e3%81%a4%e3%81%bf%e3%81%9f%e3%81%a6nisa'
+  - '%e6%a5%bd%e5%a4%a9%e8%a8%bc%e5%88%b8'
 draft: false
 id: 1101
 modified: 2021-10-05T10:18:47.000Z

--- a/posts/2021-10-07_ideco-202110/article.md
+++ b/posts/2021-10-07_ideco-202110/article.md
@@ -7,6 +7,8 @@ categories:
   - fire
 tags:
   - ideco
+  - '%e6%a5%bd%e5%a4%a9%e8%a8%bc%e5%88%b8'
+  - '%e7%a8%8e%e9%87%91'
 draft: false
 id: 1123
 modified: 2022-10-07T14:14:12.000Z

--- a/posts/2021-10-25_snowflake-snowsql/article.md
+++ b/posts/2021-10-25_snowflake-snowsql/article.md
@@ -10,6 +10,8 @@ categories:
 tags:
   - snowflake
   - snowsql
+  - mac
+  - homebrew
 draft: false
 id: 1214
 modified: 2021-10-22T12:40:03.000Z

--- a/posts/2021-10-26_snowflake-s3/article.md
+++ b/posts/2021-10-26_snowflake-s3/article.md
@@ -8,6 +8,7 @@ categories:
 tags:
   - snowflake
   - s3
+  - aws
 draft: false
 id: 1210
 modified: 2021-10-22T14:36:50.000Z

--- a/posts/2021-11-09_nisa-202111/article.md
+++ b/posts/2021-11-09_nisa-202111/article.md
@@ -7,6 +7,7 @@ categories:
   - fire
 tags:
   - '%e3%81%a4%e3%81%bf%e3%81%9f%e3%81%a6nisa'
+  - '%e6%a5%bd%e5%a4%a9%e8%a8%bc%e5%88%b8'
 draft: false
 id: 1242
 modified: 2021-11-08T19:42:21.000Z

--- a/posts/2021-11-11_ideco-202111/article.md
+++ b/posts/2021-11-11_ideco-202111/article.md
@@ -7,6 +7,8 @@ categories:
   - fire
 tags:
   - ideco
+  - '%e6%a5%bd%e5%a4%a9%e8%a8%bc%e5%88%b8'
+  - '%e7%a8%8e%e9%87%91'
 draft: false
 id: 1249
 modified: 2021-12-09T17:27:49.000Z

--- a/posts/2021-12-09_nisa-202112/article.md
+++ b/posts/2021-12-09_nisa-202112/article.md
@@ -7,6 +7,7 @@ categories:
   - fire
 tags:
   - '%e3%81%a4%e3%81%bf%e3%81%9f%e3%81%a6nisa'
+  - '%e6%a5%bd%e5%a4%a9%e8%a8%bc%e5%88%b8'
 draft: false
 id: 1318
 modified: 2021-12-09T17:27:02.000Z

--- a/posts/2021-12-10_ideco-202112/article.md
+++ b/posts/2021-12-10_ideco-202112/article.md
@@ -7,6 +7,7 @@ categories:
   - fire
 tags:
   - ideco
+  - '%e6%a5%bd%e5%a4%a9%e8%a8%bc%e5%88%b8'
 draft: false
 id: 1324
 modified: 2021-12-09T17:57:28.000Z

--- a/posts/2021-12-13_smartc/article.md
+++ b/posts/2021-12-13_smartc/article.md
@@ -4,9 +4,10 @@ slug: smartc
 date: 2021-12-13T19:30:00.000Z
 categories:
   - advertisement
-  - wordpress
 tags:
   - smart-c
+  - asp
+  - '%e3%82%a2%e3%83%95%e3%82%a7%e3%83%aa%e3%82%a8%e3%82%a4%e3%83%88'
 draft: false
 id: 1329
 modified: 2021-12-09T19:32:52.000Z

--- a/posts/2021-12-14_zucks/article.md
+++ b/posts/2021-12-14_zucks/article.md
@@ -4,9 +4,10 @@ slug: zucks
 date: 2021-12-14T19:30:00.000Z
 categories:
   - advertisement
-  - wordpress
 tags:
   - zucks
+  - asp
+  - '%e3%82%a2%e3%83%95%e3%82%a7%e3%83%aa%e3%82%a8%e3%82%a4%e3%83%88'
 draft: false
 id: 1363
 modified: 2021-12-10T11:31:25.000Z

--- a/posts/2021-12-15_accesstrade/article.md
+++ b/posts/2021-12-15_accesstrade/article.md
@@ -4,9 +4,10 @@ slug: accesstrade
 date: 2021-12-15T19:30:00.000Z
 categories:
   - advertisement
-  - wordpress
 tags:
   - '%e3%82%a2%e3%82%af%e3%82%bb%e3%82%b9%e3%83%88%e3%83%ac%e3%83%bc%e3%83%89'
+  - asp
+  - '%e3%82%a2%e3%83%95%e3%82%a7%e3%83%aa%e3%82%a8%e3%82%a4%e3%83%88'
 draft: false
 id: 1389
 modified: 2021-12-10T14:07:37.000Z

--- a/posts/2022-01-07_nisa-ideco-202201/article.md
+++ b/posts/2022-01-07_nisa-ideco-202201/article.md
@@ -8,6 +8,7 @@ categories:
 tags:
   - '%e3%81%a4%e3%81%bf%e3%81%9f%e3%81%a6nisa'
   - ideco
+  - '%e6%a5%bd%e5%a4%a9%e8%a8%bc%e5%88%b8'
 draft: false
 id: 1426
 modified: 2022-02-03T10:18:11.000Z

--- a/posts/2022-02-04_nisa-ideco-202202/article.md
+++ b/posts/2022-02-04_nisa-ideco-202202/article.md
@@ -8,6 +8,7 @@ categories:
 tags:
   - '%e3%81%a4%e3%81%bf%e3%81%9f%e3%81%a6nisa'
   - ideco
+  - '%e6%a5%bd%e5%a4%a9%e8%a8%bc%e5%88%b8'
 draft: false
 id: 1555
 modified: 2022-02-03T11:09:55.000Z

--- a/posts/2022-03-04_nisa-ideco-202203/article.md
+++ b/posts/2022-03-04_nisa-ideco-202203/article.md
@@ -8,6 +8,7 @@ categories:
 tags:
   - '%e3%81%a4%e3%81%bf%e3%81%9f%e3%81%a6nisa'
   - ideco
+  - '%e6%a5%bd%e5%a4%a9%e8%a8%bc%e5%88%b8'
 draft: false
 id: 1616
 modified: 2022-03-03T14:25:17.000Z

--- a/posts/2022-05-13_blog-update-plan/article.md
+++ b/posts/2022-05-13_blog-update-plan/article.md
@@ -5,7 +5,7 @@ date: 2022-05-13T20:00:00.000Z
 categories:
   - profile
 tags:
-  - wordpress
+  - blog-management
 draft: false
 id: 1639
 modified: 2022-05-13T12:39:11.000Z

--- a/posts/2022-07-04_google-adsense/article.md
+++ b/posts/2022-07-04_google-adsense/article.md
@@ -6,6 +6,8 @@ categories:
   - advertisement
 tags:
   - google-adsense
+  - wordpress
+  - cocoon
 draft: false
 id: 1692
 modified: 2022-07-03T14:40:37.000Z

--- a/posts/2022-10-11_api-gateway-log-with-athena/article.md
+++ b/posts/2022-10-11_api-gateway-log-with-athena/article.md
@@ -9,7 +9,7 @@ categories:
 tags:
   - athena
   - terraform
-  - api-gatewat
+  - api-gateway
 draft: false
 id: 1772
 modified: 2022-10-11T11:27:40.000Z

--- a/posts/2026-01-03_claude-code-wordpress-markdown/article.md
+++ b/posts/2026-01-03_claude-code-wordpress-markdown/article.md
@@ -7,6 +7,8 @@ categories:
   - ai
 tags:
   - wordpress
+  - claude-code
+  - golang
 draft: false
 id: 1903
 modified: '2026-01-03T00:00:00+09:00'

--- a/posts/2026-01-13_antigravity-workflow/article.md
+++ b/posts/2026-01-13_antigravity-workflow/article.md
@@ -7,6 +7,8 @@ categories:
   - ai
 tags:
   - wordpress
+  - antigravity
+  - gemini
 draft: false
 id: 2205
 modified: '2026-01-13T00:00:00+09:00'

--- a/posts/2026-01-14_ai-settings-dotfiles/article.md
+++ b/posts/2026-01-14_ai-settings-dotfiles/article.md
@@ -7,6 +7,9 @@ categories:
   - ai
 tags:
   - dotfiles
+  - claude-code
+  - cursor
+  - mac
 draft: false
 id: 2213
 modified: '2026-01-14T00:00:00+09:00'

--- a/posts/2026-01-27_cursor-image-generation/article.md
+++ b/posts/2026-01-27_cursor-image-generation/article.md
@@ -7,6 +7,8 @@ categories:
   - ai
 tags:
   - wordpress
+  - cursor
+  - antigravity
 draft: false
 id: 2227
 modified: '2026-01-27T00:00:00+09:00'

--- a/posts/2026-02-08_multi-agent-mcp-workflow/article.md
+++ b/posts/2026-02-08_multi-agent-mcp-workflow/article.md
@@ -4,8 +4,12 @@ slug: multi-agent-mcp-workflow
 date: '2026-02-08T00:00:00+09:00'
 categories:
   - ai
+  - engineering
 tags:
   - ai
+  - mcp
+  - claude-code
+  - codex
 draft: false
 id: 2231
 modified: '2026-02-08T00:00:00+09:00'

--- a/posts/2026-03-04_google-genmedia-mcp-setup/article.md
+++ b/posts/2026-03-04_google-genmedia-mcp-setup/article.md
@@ -4,7 +4,10 @@ slug: google-genmedia-mcp-setup
 date: 2026-03-04T19:27:41.000Z
 categories:
   - ai
-tags: []
+  - engineering
+tags:
+  - mcp
+  - gemini
 draft: false
 id: 2244
 modified: 2026-03-04T19:27:41.000Z

--- a/posts/2026-06-18_wordpress-to-astro-cloudflare-pages/article.md
+++ b/posts/2026-06-18_wordpress-to-astro-cloudflare-pages/article.md
@@ -9,6 +9,8 @@ tags:
   - wordpress
   - conoha-wing
   - github
+  - astro
+  - cloudflare
 draft: false
 id: 2245
 excerpt: ConoHa WING上のWordPressブログをAstro + Cloudflare Pagesの静的サイトへ移行した実体験の記録です。旧URLの維持、プラグイン機能の再実装、CI/CD構築、そして正直なハマりどころまでまとめました。

--- a/public/_redirects
+++ b/public/_redirects
@@ -39,3 +39,4 @@
 /wordpress/advertisement/google-adsence/ /wordpress/advertisement/google-adsense/ 301
 /tag/google-adsence/ /tag/google-adsense/ 301
 /fire/%E7%AF%80%E7%B4%84/post-1834/ /fire/savings/post-1834/ 301
+/tag/api-gatewat/ /tag/api-gateway/ 301


### PR DESCRIPTION
## 概要

全86投稿のカテゴリ/タグの妥当性を監査し、是正しました。WordПress時代に機械的に付いた誤分類の除去、運用実績シリーズへのタグ補完、2026年AI記事のツールタグ整備、タグ辞書のタイポ修正などを含みます。

## 変更内容

### タグ辞書（data/tags.json）
- **新規タグ追加**: Claude Code / Cursor / Antigravity / Gemini / MCP / Codex / Astro / Cloudflare / ブログ運営
- **タイポ修正**: 「API Gatewat」→「API Gateway」（**slug も `api-gatewat`→`api-gateway` に修正**し旧タグURLを301）、「アフェリエイト」→「アフィリエイト」（表示名のみ。タグURLは enSlug の `/tag/affiliate/` で元々クリーン）
- **孤立タグ削除**: `worfpress`（タイポ。唯一の使用記事を `wordpress` に付け替え）

### 記事のカテゴリ/タグ是正（31記事）
- **WordPress 誤付与の除去**: google-keyword-planner / a8net / valuecommerce / smartc / zucks / accesstrade のカテゴリから WordPress を除去（広告・副業等へ）。start-blog / start-blog-2 / blog-update-plan のタグから wordpress を除去。recaptcha-hide の `worfpress`→`wordpress`
- **運用実績シリーズにタグ補完**: nisa/ideco/nisa-ideco 9記事に「楽天証券」（iDeCoは「税金」も）を追加
- **2026年 AI記事のツールタグ整備**: Claude Code / Cursor / Antigravity / Gemini / MCP / Codex / Astro / Cloudflare を各記事へ付与。multi-agent・google-genmedia は「技術」カテゴリも追加
- **既存タグでの具体性向上**: microservice(+golang)、error-internal-load-metadata(+mac)、snowflake-snowsql(+mac,homebrew)、snowflake-s3(+AWS)、google-adsense(+wordpress,cocoon)
- **0タグの解消**: meta記事 start-blog / blog-update-plan に「ブログ運営」タグを付与 → 公開記事のタグ0件をゼロに

## テストプラン

- [x] `npm run build` 成功・新規タグページ（/tag/claude-code/ 等9種）生成を確認
- [x] 公開記事のタグ0件が **0件**（旧: google-genmedia 等）
- [x] front matter のエンコードslug（楽天証券・アフィリエイト等）を既存記事と同形式で付与（folded scalar 由来の google-keyword-planner の破損も修正）
- [x] `npm run build:redirects` 再生成で差分なし（タグ/カテゴリ変更は自動リダイレクトに影響せず）・`verify:redirects` 全90URLカバー
- [x] `npm test` 全73件パス
- [ ] プレビューURL（`*.pages.dev`）でタグ/カテゴリ一覧の見た目を目視確認

## 補足
- カテゴリ除去・タグ追加はいずれも **公開URL不変**（permalinkはidベース）でリダイレクト不要
- `api-gateway` タグは **slug ごと修正済み**（旧 `/tag/api-gatewat/` → `/tag/api-gateway/` を301）。`アフィリエイト` はタグURLが `/tag/affiliate/`（enSlug）で元々クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)
