### PR TITLE
リンクカード（ブログカード）の整形機能を追加

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,7 @@
 // @ts-check
 import { defineConfig } from 'astro/config'
 import sitemap from '@astrojs/sitemap'
+import rehypeLinkCard from './src/lib/rehype-link-card.mjs'
 
 // https://astro.build/config
 export default defineConfig({
@@ -9,4 +10,7 @@ export default defineConfig({
   trailingSlash: 'always',
   build: { format: 'directory' },
   integrations: [sitemap()],
+  markdown: {
+    rehypePlugins: [rehypeLinkCard],
+  },
 })

--- a/src/lib/rehype-link-card.mjs
+++ b/src/lib/rehype-link-card.mjs
@@ -1,0 +1,121 @@
+/**
+ * rehype プラグイン: WordPress 移行で「画像 + 改行区切りテキスト」の塊に
+ * なってしまった内部リンクのブログカードを、整った横型リンクカードへ変換する。
+ *
+ * 判定: <a> の子孫に src が `s2/favicons` を含む <img>（移行カードの目印）を持つもの。
+ * 通常のリンク・画像リンクには一切手を加えない。
+ *
+ * 変換後:
+ *   <a class="link-card" href title>
+ *     <span class="link-card__thumb"><img(eyecatch)></span>
+ *     <span class="link-card__body">
+ *       <span class="link-card__title">タイトル</span>
+ *       <span class="link-card__excerpt">要約</span>
+ *       <span class="link-card__meta"><img class="link-card__favicon">ドメイン · 日付</span>
+ *     </span>
+ *   </a>
+ */
+
+const FAVICON_HINT = 's2/favicons'
+const DATE_RE = /^\d{4}[./-]\d{1,2}[./-]\d{1,2}$/
+const DOMAIN_RE = /^[\w-]+(\.[\w-]+)+$/
+
+const el = (tagName, className, children) => ({
+  type: 'element',
+  tagName,
+  properties: className ? { className: Array.isArray(className) ? className : [className] } : {},
+  children: children || [],
+})
+const txt = (value) => ({ type: 'text', value })
+
+/** 部分木内の <img> 要素をすべて集める */
+function collectImgs(node, acc = []) {
+  if (!node || typeof node !== 'object') return acc
+  if (node.type === 'element' && node.tagName === 'img') acc.push(node)
+  for (const c of node.children || []) collectImgs(c, acc)
+  return acc
+}
+
+/** 部分木内のテキストノードの値を連結する */
+function collectText(node, parts = []) {
+  if (!node || typeof node !== 'object') return parts
+  if (node.type === 'text') parts.push(node.value)
+  for (const c of node.children || []) collectText(c, parts)
+  return parts
+}
+
+const imgSrc = (img) => String((img.properties && img.properties.src) || '')
+const isLinkCard = (a) => collectImgs(a).some((img) => imgSrc(img).includes(FAVICON_HINT))
+
+/**
+ * ブログカードの <a> 要素を整形カードへ書き換える。
+ * 構造が想定外（行が少なすぎる等）の場合は false を返して変換しない。
+ */
+export function transformLinkCard(a) {
+  const imgs = collectImgs(a)
+  const favicon = imgs.find((img) => imgSrc(img).includes(FAVICON_HINT))
+  const eyecatch = imgs.find((img) => img !== favicon)
+
+  const lines = collectText(a)
+    .join('\n')
+    .split('\n')
+    .map((s) => s.trim())
+    .filter(Boolean)
+  if (lines.length < 2) return false
+
+  const rest = [...lines]
+  let date = ''
+  if (DATE_RE.test(rest[rest.length - 1])) date = rest.pop()
+  let domain = ''
+  if (rest.length && DOMAIN_RE.test(rest[rest.length - 1])) domain = rest.pop()
+  const title = rest.shift() || String((a.properties && a.properties.title) || '')
+  const excerpt = rest.join(' ')
+  if (!title) return false
+
+  if (favicon) {
+    favicon.properties = { ...favicon.properties, className: ['link-card__favicon'], alt: '', loading: 'lazy' }
+  }
+
+  const meta = []
+  if (favicon) meta.push(favicon)
+  const metaText = [domain, date].filter(Boolean).join(' · ')
+  if (metaText) meta.push(txt(metaText))
+
+  const bodyChildren = [el('span', 'link-card__title', [txt(title)])]
+  if (excerpt) bodyChildren.push(el('span', 'link-card__excerpt', [txt(excerpt)]))
+  if (meta.length) bodyChildren.push(el('span', 'link-card__meta', meta))
+
+  const children = []
+  if (eyecatch) children.push(el('span', 'link-card__thumb', [eyecatch]))
+  children.push(el('span', 'link-card__body', bodyChildren))
+
+  a.children = children
+  const existing = (a.properties && a.properties.className) || []
+  a.properties = {
+    ...a.properties,
+    className: [...(Array.isArray(existing) ? existing : [existing]), 'link-card'],
+  }
+  return true
+}
+
+/** hast を走査して全ブログカードを変換する（テスト用に分離） */
+export function transformTree(tree) {
+  let count = 0
+  const walk = (node) => {
+    if (!node || typeof node !== 'object') return
+    if (node.type === 'element' && node.tagName === 'a' && isLinkCard(node)) {
+      if (transformLinkCard(node)) count++
+      return // カード内部はこれ以上掘らない
+    }
+    for (const c of node.children || []) walk(c)
+  }
+  walk(tree)
+  return count
+}
+
+/** rehype プラグイン本体 */
+export default function rehypeLinkCard() {
+  return (tree) => {
+    transformTree(tree)
+  }
+}

--- a/src/lib/rehype-link-card.test.ts
+++ b/src/lib/rehype-link-card.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+// @ts-expect-error - plain JS module
+import { transformTree, transformLinkCard } from './rehype-link-card.mjs'
+
+const el = (tagName: string, properties: any, children: any[] = []) => ({ type: 'element', tagName, properties, children })
+const txt = (value: string) => ({ type: 'text', value })
+
+/** 移行ブログカード相当の <a>（img + <br>区切りテキスト + favicon + ドメイン + 日付） */
+function makeCardAnchor() {
+  return el('a', { href: '/fire/nisa-202110/', title: 'タイトルA' }, [
+    el('img', { src: '/_astro/eyecatch.webp', alt: '' }),
+    el('br', {}),
+    txt('\n'),
+    el('br', {}),
+    txt('\n【つみたてNISA】15ヶ月目の運用実績公開！| 2021年10月'),
+    el('br', {}),
+    txt('\n'),
+    el('br', {}),
+    txt('\n楽天証券でつみたてNISAを初めて、15ヶ月目の運用実績を紹介します。'),
+    el('br', {}),
+    el('img', { src: 'https://www.google.com/s2/favicons?domain=https://shiimanblog.com', alt: '' }),
+    el('br', {}),
+    txt('\nshiimanblog.com'),
+    el('br', {}),
+    txt('\n2021.10.06'),
+  ])
+}
+
+const findClass = (node: any, cls: string): any => {
+  if (node?.type === 'element' && (node.properties?.className || []).includes(cls)) return node
+  for (const c of node?.children || []) {
+    const r = findClass(c, cls)
+    if (r) return r
+  }
+  return null
+}
+const textOf = (node: any): string =>
+  node?.type === 'text' ? node.value : (node?.children || []).map(textOf).join('')
+
+describe('transformLinkCard', () => {
+  it('移行ブログカードを横型カード構造へ変換する', () => {
+    const a = makeCardAnchor()
+    expect(transformLinkCard(a)).toBe(true)
+    expect(a.properties.className).toContain('link-card')
+    expect(findClass(a, 'link-card__thumb')).toBeTruthy()
+    expect(textOf(findClass(a, 'link-card__title'))).toBe('【つみたてNISA】15ヶ月目の運用実績公開！| 2021年10月')
+    expect(textOf(findClass(a, 'link-card__excerpt'))).toContain('楽天証券でつみたてNISAを初めて')
+    expect(textOf(findClass(a, 'link-card__meta'))).toBe('shiimanblog.com · 2021.10.06')
+  })
+
+  it('favicon に link-card__favicon クラスを付与する', () => {
+    const a = makeCardAnchor()
+    transformLinkCard(a)
+    const fav = findClass(a, 'link-card__favicon')
+    expect(fav?.tagName).toBe('img')
+    expect(fav.properties.src).toContain('s2/favicons')
+  })
+})
+
+describe('transformTree', () => {
+  it('ツリー内のブログカードのみ変換し、通常リンクは触らない', () => {
+    const normal = el('a', { href: '/foo/' }, [txt('普通のリンク')])
+    const tree = el('div', {}, [el('p', {}, [makeCardAnchor()]), el('p', {}, [normal])])
+    const count = transformTree(tree)
+    expect(count).toBe(1)
+    expect(normal.properties.className).toBeUndefined()
+    expect(textOf(normal)).toBe('普通のリンク')
+  })
+
+  it('favicon を含まないリンクはカード化しない', () => {
+    const a = el('a', { href: '/x/' }, [el('img', { src: '/img.png' }), txt('画像リンク')])
+    const tree = el('div', {}, [a])
+    expect(transformTree(tree)).toBe(0)
+    expect((a.properties.className || []).includes('link-card')).toBe(false)
+  })
+})

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -99,3 +99,74 @@ th, td {
 thead th { background: var(--bg-subtle); font-weight: 700; white-space: nowrap; }
 tbody tr:nth-child(even) { background: var(--bg-subtle); }
 table :not(pre) > code { white-space: nowrap; }
+
+/* リンクカード（内部記事のブログカード。rehype-link-card で生成） */
+.link-card {
+  display: flex;
+  gap: 16px;
+  align-items: stretch;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 14px;
+  margin: 1.5rem 0;
+  text-decoration: none;
+  color: var(--text);
+  background: var(--bg);
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+.link-card:hover {
+  background: var(--bg-subtle);
+  border-color: var(--accent);
+  text-decoration: none;
+  color: var(--text);
+}
+.link-card__thumb { flex: none; width: 160px; }
+.link-card__thumb img {
+  width: 160px;
+  height: 100px;
+  object-fit: cover;
+  border-radius: 6px;
+  display: block;
+}
+.link-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+  justify-content: center;
+}
+.link-card__title {
+  font-weight: 700;
+  font-size: 0.98rem;
+  line-height: 1.45;
+  color: var(--text);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.link-card__excerpt {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  line-height: 1.5;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.link-card__meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  margin-top: 2px;
+}
+.link-card__favicon { width: 16px; height: 16px; flex: none; border-radius: 3px; }
+
+@media (max-width: 520px) {
+  .link-card { gap: 12px; padding: 10px; }
+  .link-card__thumb { width: 96px; }
+  .link-card__thumb img { width: 96px; height: 72px; }
+  .link-card__excerpt { display: none; }
+}


### PR DESCRIPTION
## 概要

WordPress 移行で「画像＋`\`改行区切りテキストの羅列」になっていた内部/外部リンクのブログカードを、整った**横型リンクカード**として表示する機能を追加します。ビルド時の rehype プラグインで自動変換するため、記事の編集は不要です（全58枚・34記事に自動適用）。

## 変更内容

- `src/lib/rehype-link-card.mjs`（新規）: 依存追加なしの rehype プラグイン。`<a>` の子孫に `s2/favicons` の `<img>`（移行カードの目印）を持つものだけを検出し、サムネ/タイトル/要約/favicon・ドメイン・日付の構造へ書き換え。通常リンク・画像リンクには触れない
- `src/lib/rehype-link-card.test.ts`（新規）: 変換ロジックのユニットテスト（カード変換・favicon付与・通常リンク非変換・favicon無しはスキップ）
- `astro.config.mjs`: `markdown.rehypePlugins` に登録
- `src/styles/global.css`: `.link-card` 系スタイル（横型・ボーダー＋角丸・ホバー・ダークモード対応・狭幅レスポンシブ）

### 変換後の構造
```html
<a class="link-card" href="…" title="…">
  <span class="link-card__thumb"><img …eyecatch…></span>
  <span class="link-card__body">
    <span class="link-card__title">タイトル</span>
    <span class="link-card__excerpt">要約</span>
    <span class="link-card__meta"><img class="link-card__favicon">ドメイン · 日付</span>
  </span>
</a>
```

## テストプラン

- [x] `npm test` 全77件パス（rehype-link-card テスト4件追加）
- [x] `npm run build` 成功・全ページで `.link-card` を **58枚**生成（カード総数と一致）
- [x] 未変換カード（旧 favicon→`<br>` 羅列）**0**・空タイトルカード **0**
- [x] 内部リンク（nisa/ideco）・外部リンク（YouTube: 日付なしでもドメインのみ表示）ともに正常変換を確認
- [ ] プレビューURL（`*.pages.dev`）でカードの見た目（横型・サムネ・ホバー・スマホ表示）を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)