### PR TITLE
モバイルのヘッダーナビをハンバーガーメニュー化

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,7 @@
 // @ts-check
 import { defineConfig } from 'astro/config'
 import sitemap from '@astrojs/sitemap'
+import { unified } from '@astrojs/markdown-remark'
 import rehypeLinkCard from './src/lib/rehype-link-card.mjs'
 
 // https://astro.build/config
@@ -11,6 +12,8 @@ export default defineConfig({
   build: { format: 'directory' },
   integrations: [sitemap()],
   markdown: {
-    rehypePlugins: [rehypeLinkCard],
+    // Astro v6 で markdown.rehypePlugins は非推奨。unified() プロセッサ経由で渡す。
+    // syntaxHighlight(shiki)/画像最適化等は別フィールドの既定として維持される。
+    processor: unified({ rehypePlugins: [rehypeLinkCard] }),
   },
 })

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -8,14 +8,24 @@ import SearchOverlay from './SearchOverlay.astro'
       <a class="brand" href="/">しーまんブログ</a>
       <span class="brand-sub">〜楽をしたいエンジニアのブログ〜</span>
     </div>
-    <nav class="nav">
+    <nav class="nav" id="site-nav">
       <a href="/">ホーム</a>
       <a href="/profile/">プロフィール</a>
       <a href="/sitemap/">サイトマップ</a>
       <a href="/contact/">お問い合わせ</a>
+    </nav>
+    <div class="header-actions">
       <button id="search-open" type="button" class="icon-btn" aria-label="検索" title="検索">🔍</button>
       <ThemeToggle />
-    </nav>
+      <button
+        id="nav-toggle"
+        type="button"
+        class="icon-btn nav-toggle"
+        aria-label="メニュー"
+        aria-expanded="false"
+        aria-controls="site-nav"
+      >☰</button>
+    </div>
   </div>
 </header>
 <SearchOverlay />
@@ -26,17 +36,60 @@ import SearchOverlay from './SearchOverlay.astro'
     background: var(--bg);
     border-bottom: 1px solid var(--border);
   }
-  .inner { display: flex; align-items: center; justify-content: space-between; height: 60px; gap: 16px; }
-  .brand-wrap { display: flex; align-items: baseline; gap: 10px; white-space: nowrap; }
+  .inner { display: flex; align-items: center; height: 60px; gap: 16px; }
+  .brand-wrap { display: flex; align-items: baseline; gap: 10px; white-space: nowrap; margin-right: auto; }
   .brand { font-weight: 700; font-size: 1.1rem; color: var(--text); }
   .brand-sub { font-size: 0.7rem; color: var(--text-muted); font-weight: 400; }
-  .nav { display: flex; align-items: center; gap: 16px; font-size: 0.9rem; flex-wrap: wrap; justify-content: flex-end; }
+  .nav { display: flex; align-items: center; gap: 16px; font-size: 0.9rem; }
   .nav a { color: var(--text-muted); }
   .nav a:hover { color: var(--accent); text-decoration: none; }
+  .header-actions { display: flex; align-items: center; gap: 10px; }
   .icon-btn {
     background: none; border: 1px solid var(--border); color: var(--text);
     border-radius: 6px; width: 34px; height: 34px; cursor: pointer;
-    font-size: 14px; line-height: 1;
+    font-size: 14px; line-height: 1; display: inline-flex; align-items: center; justify-content: center;
   }
   .icon-btn:hover { background: var(--bg-subtle); }
+  .nav-toggle { display: none; font-size: 18px; }
+
+  /* モバイル: ナビをハンバーガーのドロップダウンに集約（PC表示は据え置き） */
+  @media (max-width: 768px) {
+    .brand-sub { display: none; }
+    .nav-toggle { display: inline-flex; }
+    .nav {
+      display: none;
+      position: absolute; top: 60px; left: 0; right: 0;
+      flex-direction: column; align-items: stretch; gap: 0;
+      background: var(--bg);
+      border-bottom: 1px solid var(--border);
+      padding: 4px 20px 8px;
+      box-shadow: 0 8px 16px rgba(0, 0, 0, 0.06);
+    }
+    .nav.open { display: flex; }
+    .nav a { padding: 13px 4px; border-bottom: 1px solid var(--border); }
+    .nav a:last-child { border-bottom: none; }
+  }
 </style>
+
+<script>
+  const toggle = document.getElementById('nav-toggle')
+  const nav = document.getElementById('site-nav')
+  if (toggle && nav) {
+    const close = () => {
+      nav.classList.remove('open')
+      toggle.setAttribute('aria-expanded', 'false')
+    }
+    toggle.addEventListener('click', () => {
+      const open = nav.classList.toggle('open')
+      toggle.setAttribute('aria-expanded', String(open))
+    })
+    nav.querySelectorAll('a').forEach((a) => a.addEventListener('click', close))
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') close()
+    })
+    document.addEventListener('click', (e) => {
+      const target = e.target as Node
+      if (nav.classList.contains('open') && !nav.contains(target) && !toggle.contains(target)) close()
+    })
+  }
+</script>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -30,6 +30,28 @@ import SearchOverlay from './SearchOverlay.astro'
 </header>
 <SearchOverlay />
 
+<noscript>
+  <!-- JS無効時のフォールバック: モバイルでもナビを常時表示し、☰ を隠す（遷移不能を防ぐ） -->
+  <style>
+    @media (max-width: 768px) {
+      .site-header .inner { height: auto; flex-wrap: wrap; padding-top: 8px; padding-bottom: 8px; }
+      .site-header .nav {
+        display: flex !important;
+        position: static !important;
+        width: 100%;
+        flex-wrap: wrap;
+        gap: 10px 16px;
+        background: none;
+        border: 0;
+        box-shadow: none;
+        padding: 0;
+      }
+      .site-header .nav a { border: 0 !important; padding: 4px 0 !important; }
+      .site-header .nav-toggle { display: none !important; }
+    }
+  </style>
+</noscript>
+
 <style>
   .site-header {
     position: sticky; top: 0; z-index: 50;
@@ -76,6 +98,8 @@ import SearchOverlay from './SearchOverlay.astro'
   const nav = document.getElementById('site-nav')
   if (toggle && nav) {
     const close = () => {
+      // フォーカスがナビ内に残ったまま非表示になるのを防ぐ（キーボード可用性）
+      if (nav.contains(document.activeElement)) (toggle as HTMLElement).focus()
       nav.classList.remove('open')
       toggle.setAttribute('aria-expanded', 'false')
     }


### PR DESCRIPTION
## 概要

スマホ（iPhone 12 mini 等の狭幅）でヘッダーのナビゲーションが折り返し、固定高(60px)の sticky ヘッダーからはみ出して本文右上に被る不具合を修正します。狭幅ではナビをハンバーガーメニューに集約します。**PC表示は現状維持**。

## 原因
- `.inner` が固定 `height: 60px` の sticky ヘッダー
- 右の `.nav` が `flex-wrap: wrap` で、狭幅では4リンクが縦に折り返し、60px高からあふれて本文に重なっていた（レスポンシブ未対応）

## 変更内容（`src/components/Header.astro`）
- ナビリンク(.nav)とアクション(.header-actions: 検索🔍 / テーマ切替 / ☰)を分離
- 768px以下で:
  - 副題「〜楽をしたいエンジニアのブログ〜」を非表示
  - ☰ ボタンを表示、`.nav` をヘッダー直下のドロップダウン（`position: absolute`）に。既定は非表示で、☰ トグルで開閉（`.open`）
- ☰ クリックで開閉、リンククリック/Escape/外側クリックで閉じる軽量JS（aria-expanded 連動）
- 769px以上は従来どおり横並び・☰ 非表示

## テストプラン（Playwright で実機相当を確認）
- [x] モバイル375px: ヘッダーは「ブランド＋🔍＋テーマ＋☰」で本文への被りなし
- [x] ☰ タップで4リンク（ホーム/プロフィール/サイトマップ/お問い合わせ）のドロップダウンが開く
- [x] デスクトップ1280px: フルナビ表示・☰ 非表示で**従来と同一**
- [x] `npm test` 全77件パス・`npm run build` 成功
- [ ] 実機（iPhone）で最終確認



## あわせて対応: markdown 設定の非推奨解消

AstroのプレビューでPR #35（リンクカード）の `markdown.rehypePlugins` が **Astro v6 で非推奨**警告を出していたため、推奨方式へ移行しました。
- `astro.config.mjs`: `markdown.rehypePlugins` → `markdown.processor: unified({ rehypePlugins: [rehypeLinkCard] })`（`@astrojs/markdown-remark` の `unified()`）
- 検証: deprecation警告 **0**・リンクカード/シンタックスハイライト(shiki)/画像最適化(webp)/GFMテーブル/見出しアンカーID すべて維持・`npm test` 77件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)
